### PR TITLE
fix: make blur seamless

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -22,7 +22,6 @@ export default function RootLayout() {
             options={{
               title: "Hello",
               headerTransparent: true,
-              headerBlurEffect: "systemChromeMaterial",
               headerLargeTitleShadowVisible: false,
               headerLargeStyle: {
                 backgroundColor: "transparent",

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,4 +1,4 @@
-import { StyleSheet, Text } from "react-native";
+import { StyleProp, StyleSheet, Text, ViewStyle } from "react-native";
 
 import Masked from "@react-native-masked-view/masked-view";
 import { BlurView } from "expo-blur";
@@ -54,34 +54,34 @@ export default function HomeScreen() {
   );
 }
 
-function Glur({ direction, style }: { direction: "top" | "bottom" }) {
+function Glur({
+  direction,
+  style,
+}: {
+  direction: "top" | "bottom";
+  style: StyleProp<ViewStyle>;
+}) {
   const headerHeight = useReanimatedHeaderHeight();
+
+  const blurHeight = useAnimatedStyle(() => ({
+    height: headerHeight.value * 1.5,
+  }));
+
   return (
     <AnimMask
       maskElement={
         <Animated.View
           style={[
+            StyleSheet.absoluteFill,
             {
-              position: "absolute",
-              top: 0,
-              left: 0,
-              right: 0,
-              bottom: 0,
               backgroundColor: "transparent",
-              experimental_backgroundImage: `linear-gradient(to ${direction}, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 1) 75%)`,
+              experimental_backgroundImage: `linear-gradient(to ${direction}, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 1) 33%)`,
             },
             style,
           ]}
         />
       }
-      style={{
-        position: "absolute",
-        top: headerHeight,
-        left: 0,
-        right: 0,
-        bottom: 0,
-        height: 96,
-      }}
+      style={[StyleSheet.absoluteFill, blurHeight]}
     >
       <BlurView
         intensity={100}


### PR DESCRIPTION
Hello!

First of all, love the example you shared. Thank you very much.

I just noticed that there was a clear separation between the gradient from the native header and the blur gradient. This PR solves that by making the blur into a single background element, which makes it appear as a seamless progressive blur.

Here are the screenshots:

## Before

![before](https://github.com/user-attachments/assets/c0b42fe6-1edb-4ece-93be-53ddd6f82549)

## After

![fixed](https://github.com/user-attachments/assets/ec544c99-e8a8-4daa-8988-98ffeb169523)

## What changed?

I simply removed the background blur from the Stack on the `_layout.tsx` and switched the blur to the `Glur` component, which will be a little bit taller than the header (50% taller) to make the progressive blur more apparent and make the gradient stop exactly where the native header is supposed to start, by making the linear gradient stop at 33%.

Of course, the effect can be made more prominent by making the `Glur` taller and adjusting the linear gradient to your heart's desire.

Hope this is useful!